### PR TITLE
fix: schedule_out_of_stockエラーのみを満席判定に修正

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@
 // @run-at       document-end
 // ==/UserScript==
 
-// Built: 2025/10/11 04:06:13
+// Built: 2025/10/11 04:59:54
 
 
 (function webpackUniversalModuleDefinition(root, factory) {
@@ -39842,7 +39842,7 @@ const usePavilionsStore = (0,pinia/* defineStore */.nY)('pavilions', () => {
                     errorData: data.error,
                     fullResponse: data
                 });
-                if (errorName === 'fetch_remainder_failed') {
+                if (errorName === 'schedule_out_of_stock') {
                     failureReason = '満席';
                 }
                 else if (errorName === 'th_error') {

--- a/ts/stores/pavilions.ts
+++ b/ts/stores/pavilions.ts
@@ -747,7 +747,7 @@ export const usePavilionsStore = defineStore('pavilions', () => {
           fullResponse: data
         })
 
-        if (errorName === 'fetch_remainder_failed') {
+        if (errorName === 'schedule_out_of_stock') {
           failureReason = '満席'
         } else if (errorName === 'th_error') {
           failureReason = '無効'


### PR DESCRIPTION
- fetch_remainder_failedから変更してschedule_out_of_stockエラーのみが満席として分類されるように修正
- 「指定されたプログラムの在庫が確保できませんでした。」メッセージが適切に満席判定されるようになる
- その他のエラー判定（無効：th_error、select ticket valid error）は維持