### PR TITLE
fix: パビリオン検索並列度を10件に向上とお気に入り検索キャンセル機能を修正

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@
 // @run-at       document-end
 // ==/UserScript==
 
-// Built: 2025/10/11 04:59:54
+// Built: 2025/10/11 05:18:53
 
 
 (function webpackUniversalModuleDefinition(root, factory) {


### PR DESCRIPTION
- パビリオン検索の並列度を5件から10件に向上し、検索パフォーマンスを2倍に改善
- お気に入り検索でキャンセルボタンが機能しない問題を修正
- getTimeSlotsForPavilions関数にAbortSignalサポートを追加
- loadFavoritePavilions関数にAbortSignal連携を実装
- キャンセル時の適切な処理中断とエラーハンドリングを追加

🤖 Generated with [Claude Code](https://claude.ai/code)